### PR TITLE
Stop animate function if fn returns false

### DIFF
--- a/lib/gmynd.js
+++ b/lib/gmynd.js
@@ -216,13 +216,16 @@ GSVG.doc.addEventListener('mouseup', function(e) {
 function animate(fn, fps) {
   var then = Date.now();
   var frameCount = 0;
+  var fnReturnValue;
 
   // custom fps, otherwise fallback to 60
   fps = fps || 60;
   var interval = 1000 / fps;
 
   return (function loop(time){
-      requestAnimationFrame(loop);
+      if( !(fnReturnValue === false) ){
+        requestAnimationFrame(loop);
+      }
 
       var now = new Date().getTime();
       var delta = now - then;
@@ -230,7 +233,7 @@ function animate(fn, fps) {
       if (delta > interval) {
           then = now - (delta % interval);
           frameCount++;
-          fn(frameCount);
+          fnReturnValue = fn(frameCount);
       }
   }(0));
 };

--- a/tests/cancel-animation-test.html
+++ b/tests/cancel-animation-test.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>GMYND test</title>
+  <meta charset="utf-8">
+  <link rel="stylesheet" type="text/css" href="../lib/gmynd_base.css">
+</head>
+<body>
+
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600"></svg>
+
+<div>
+  Cancel Animation Test
+</div>
+
+<script src="../lib/gmynd.js" type="text/javascript"></script>
+<script type="text/javascript">
+var rect = createNode("rect", {
+  x: 0, y:0,
+  width: 100,
+  height: 100
+});
+animate(function(frameCount) {
+  if(frameCount == 500)
+    return false;
+
+  rect.setAttribute("x", frameCount);
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Added possibility to end animation by returning false from animation function. Excerpt from tests/cancel-animation-test.html:

``` javascript
var rect = createNode("rect", {
  x: 0, y:0,
  width: 100,
  height: 100
});
animate(function(frameCount) {
  if(frameCount == 500)
    return false;

  rect.setAttribute("x", frameCount);
});
```
